### PR TITLE
Add Ryan to members

### DIFF
--- a/src/vanclj/core.clj
+++ b/src/vanclj/core.clj
@@ -65,7 +65,7 @@
 (defn member-section [members]
   [:div.tile.is-ancestor
    [:div.tile.is-vertical
-    (for [members (partition-all 4 (take 8 members))]
+    (for [members (partition-all 4 members)]
       [:div.tile.is-parent
        (for [{:keys [name website avatar twitter github]} members]
          [:div.tile.is-child.box.has-text-centered

--- a/src/vanclj/members.clj
+++ b/src/vanclj/members.clj
@@ -58,4 +58,9 @@
 
    {:name   "David Dossot"
     :github "https://github.com/ddossot"
-    :twitter "https://twitter.com/ddossot"}])
+    :twitter "https://twitter.com/ddossot"}
+
+   {:name "Ryan McCuaig"
+    :avatar "http://2.gravatar.com/avatar/814feeb82ede969c68d62512f3da2aec"
+    :github "https://github.com/rgm"
+    :twitter "https://twitter.com/rgm"}])

--- a/src/vanclj/members.clj
+++ b/src/vanclj/members.clj
@@ -61,6 +61,6 @@
     :twitter "https://twitter.com/ddossot"}
 
    {:name "Ryan McCuaig"
-    :avatar "http://2.gravatar.com/avatar/814feeb82ede969c68d62512f3da2aec"
+    :avatar "https://2.gravatar.com/avatar/814feeb82ede969c68d62512f3da2aec"
     :github "https://github.com/rgm"
     :twitter "https://twitter.com/rgm"}])


### PR DESCRIPTION
- Activates all members; gets rid of `(take 8 ,,,)` clipping.
- Trying gravatar urls for the avatar to avoid having to fork 2 repos,
  since it looks like `/public` is a submodule.